### PR TITLE
Added unofficial code for FM-GAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is a paper list for style transfer in text. It also contains some related r
 - Learning Criteria and Evaluation Metrics for Textual Transfer between Non-Parallel Corpora, Arxiv, 2018, [[paper]](https://arxiv.org/abs/1810.11878)
 - Content preserving text generation with attribute controls, NIPS, 2018, [[paper]](https://arxiv.org/abs/1811.01135)
 - QuaSE: Sequence Editing under Quantifiable Guidance, EMNLP, 2018, [[paper]](http://aclweb.org/anthology/D18-1420)
-- Adversarial Text Generation via Feature-Mover's Distance, NeurIPS, 2018, [[paper]](https://arxiv.org/abs/1809.06297), [[code]](https://github.com/LiqunChen0606/FM-GAN)
+- Adversarial Text Generation via Feature-Mover's Distance, NeurIPS, 2018, [[paper]](https://arxiv.org/abs/1809.06297), [[unofficial code]](https://github.com/knok/chainer-fm-gan)
 - Towards Controlled Transformation of Sentiment in Sentences, ICAART, 2019, [[paper]](https://arxiv.org/abs/1901.11467)
 - Formality Style Transfer with Hybrid Textual Annotations, Arxiv, 2019, [[paper]](https://arxiv.org/abs/1903.06353)
 - Reinforcement Learning Based Text Style Transfer without Parallel Training Corpus, NAACL-2019, 2019, [[paper]](https://arxiv.org/abs/1903.10671)


### PR DESCRIPTION
Since link for official implementation of "Adversarial Text Generation via
Feature-Mover’s Distance"  (https://github.com/LiqunChen0606/FM-GAN) is not working i deleted it and added unofficial code instead (https://github.com/knok/chainer-fm-gan).